### PR TITLE
Bump depandencies to avoid vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,11 @@
     "styled-components": "^4.1.2",
     "uuid": "^3.3.2"
   },
+  "resolutions": {
+    "handlebars": "^4.5.3",
+    "lodash": "^4.17.12",
+    "https-proxy-agent": "^2.2.3"
+  },
   "jest": {
     "transform": {
       ".(ts|tsx)": "ts-jest"

--- a/react-example/package.json
+++ b/react-example/package.json
@@ -14,6 +14,13 @@
     "react-dom": "^16.8.4",
     "react-scripts": "2.1.5"
   },
+  "resolutions": {
+    "handlebars": "^4.5.3",
+    "eslint-utils": "^1.4.1",
+    "lodash": "^4.17.12",
+    "mixin-deep": "^1.3.2",
+    "set-value": "^2.0.1"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/react-example/yarn.lock
+++ b/react-example/yarn.lock
@@ -4919,10 +4919,10 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
   integrity sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
 
-handlebars@^4.0.3:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.1.tgz#6e4e41c18ebe7719ae4d38e5aca3d32fa3dd23d3"
-  integrity sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==
+handlebars@^4.0.3, handlebars@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
+  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6638,10 +6638,10 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
   integrity sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
 
-handlebars@*, handlebars@^4.0.6, handlebars@^4.1.0, handlebars@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
-  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
+handlebars@*, handlebars@^4.0.6, handlebars@^4.1.0, handlebars@^4.1.2, handlebars@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
+  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
I found the PR from `dependabot` won't fix all the vulnerabilities. I searched online and found others also experienced this issue
![image](https://user-images.githubusercontent.com/14008461/71926854-1197cc00-31f9-11ea-8a05-b54fe428ac24.png)
So I create a PR by myself for fixing the vulnerabilities.

After the fix, the extension and react-example all pass the yarn audit.
And I tested the project by running the react-example, building the extension and running the extension on chrome.
![image](https://user-images.githubusercontent.com/14008461/71927033-7bb07100-31f9-11ea-96e8-ee0972dfc632.png)

